### PR TITLE
feat: Privacy Policy & Terms of Service pages (A2P 10DLC compliance)

### DIFF
--- a/sanity/schemas/index.js
+++ b/sanity/schemas/index.js
@@ -12,6 +12,7 @@ import financialReport from './financialReport';
 import nonprofitInfo from './nonprofitInfo';
 import championshipResult from './championshipResult'; 
 import newsletterEmail from './newsletterEmail';
+import legalDocument from './legalDocument';
 
 export const schemaTypes = [
   sponsor,
@@ -23,6 +24,7 @@ export const schemaTypes = [
   meetingAgenda,
   financialReport,
   nonprofitInfo,
-  championshipResult, 
+  championshipResult,
   newsletterEmail,
+  legalDocument,
 ];

--- a/sanity/schemas/legalDocument.js
+++ b/sanity/schemas/legalDocument.js
@@ -1,0 +1,78 @@
+export default {
+  name: 'legalDocument',
+  title: 'Legal Documents',
+  type: 'document',
+  fields: [
+    {
+      name: 'title',
+      title: 'Document Title',
+      type: 'string',
+      validation: Rule => Rule.required(),
+      description: 'e.g. "Privacy Policy" or "Terms of Service"',
+    },
+    {
+      name: 'slug',
+      title: 'Slug',
+      type: 'slug',
+      options: { source: 'title' },
+      validation: Rule => Rule.required(),
+      description: 'Used in the URL. Use "privacy-policy" or "terms-of-service".',
+    },
+    {
+      name: 'effectiveDate',
+      title: 'Effective Date',
+      type: 'date',
+      validation: Rule => Rule.required(),
+    },
+    {
+      name: 'lastUpdated',
+      title: 'Last Updated',
+      type: 'date',
+      validation: Rule => Rule.required(),
+    },
+    {
+      name: 'intro',
+      title: 'Introduction Paragraph',
+      type: 'text',
+      rows: 4,
+      description: 'Optional introductory paragraph shown before the sections.',
+    },
+    {
+      name: 'sections',
+      title: 'Sections',
+      type: 'array',
+      of: [
+        {
+          type: 'object',
+          fields: [
+            {
+              name: 'heading',
+              title: 'Section Heading',
+              type: 'string',
+              validation: Rule => Rule.required(),
+            },
+            {
+              name: 'body',
+              title: 'Section Content',
+              type: 'text',
+              rows: 8,
+              description: 'Supports basic markdown: **bold**, *italic*, bullet lists with "- item"',
+            },
+          ],
+          preview: {
+            select: { title: 'heading' },
+          },
+        },
+      ],
+    },
+    {
+      name: 'contactEmail',
+      title: 'Contact Email for Policy Questions',
+      type: 'string',
+      description: 'Email address shown at the bottom of the document.',
+    },
+  ],
+  preview: {
+    select: { title: 'title', subtitle: 'effectiveDate' },
+  },
+};

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,6 +20,8 @@ import { Schedule } from "./pages/Schedule";
 import { Transparency } from "./pages/Transparency";
 import { Champions } from "./pages/Champions";
 import { NewsletterArchive } from "./pages/NewsletterArchive";
+import { PrivacyPolicy } from "./pages/PrivacyPolicy";
+import { TermsOfService } from "./pages/TermsOfService";
 
 function App() {
   return (
@@ -45,6 +47,8 @@ function App() {
             <Route path="/coach-help" element={<CoachHelp />} />
             <Route path="/champions" element={<Champions />} />
             <Route path="/newsletter-archive" element={<NewsletterArchive />} />
+            <Route path="/privacy-policy" element={<PrivacyPolicy />} />
+            <Route path="/terms-of-service" element={<TermsOfService />} />
 
             <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>

--- a/src/components/layout/Footer.jsx
+++ b/src/components/layout/Footer.jsx
@@ -169,6 +169,15 @@ export const Footer = () => {
           <p className="mt-2 text-sm">
             Committed to transparency and fair play in Idaho gaming.
           </p>
+          <div className="mt-3 flex justify-center gap-4 text-xs text-gray-500">
+            <a href="/privacy-policy" className="hover:text-purple-400 transition-colors">
+              Privacy Policy
+            </a>
+            <span>·</span>
+            <a href="/terms-of-service" className="hover:text-purple-400 transition-colors">
+              Terms of Service
+            </a>
+          </div>
         </div>
       </div>
     </footer>

--- a/src/components/newsletter/NewsletterSignup.jsx
+++ b/src/components/newsletter/NewsletterSignup.jsx
@@ -150,6 +150,15 @@ export const NewsletterSignup = ({ inline = false }) => {
                 <strong className="text-gray-400">STOP</strong> to cancel,{" "}
                 <strong className="text-gray-400">HELP</strong> for help.
                 Consent is not a condition of purchase or participation.
+                View our{" "}
+                <a href="/privacy-policy" className="underline hover:text-gray-300">
+                  Privacy Policy
+                </a>
+                {" "}and{" "}
+                <a href="/terms-of-service" className="underline hover:text-gray-300">
+                  Terms of Service
+                </a>
+                .
               </p>
             </div>
           )}

--- a/src/pages/LegalDocument.jsx
+++ b/src/pages/LegalDocument.jsx
@@ -1,0 +1,138 @@
+import React, { useEffect, useState } from "react";
+import { FileText } from "lucide-react";
+import { queries } from "../services/sanity";
+
+const renderBody = (text) => {
+  if (!text) return null;
+  return text.split("\n\n").map((para, i) => {
+    // Bullet list block
+    if (para.trim().startsWith("- ")) {
+      const items = para
+        .split("\n")
+        .filter((l) => l.trim().startsWith("- "))
+        .map((l) => l.replace(/^- /, ""));
+      return (
+        <ul key={i} className="list-disc list-inside space-y-1 mb-4 text-gray-300">
+          {items.map((item, j) => (
+            <li key={j} dangerouslySetInnerHTML={{ __html: inlineMarkdown(item) }} />
+          ))}
+        </ul>
+      );
+    }
+    return (
+      <p
+        key={i}
+        className="text-gray-300 mb-4 leading-relaxed"
+        dangerouslySetInnerHTML={{ __html: inlineMarkdown(para) }}
+      />
+    );
+  });
+};
+
+const inlineMarkdown = (text) =>
+  text
+    .replace(/\*\*(.+?)\*\*/g, "<strong class=\"text-white\">$1</strong>")
+    .replace(/\*(.+?)\*/g, "<em>$1</em>");
+
+export const LegalDocument = ({ slug }) => {
+  const [doc, setDoc] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    queries
+      .getLegalDocument(slug)
+      .then((data) => {
+        setDoc(data);
+        setLoading(false);
+      })
+      .catch(() => {
+        setError(true);
+        setLoading(false);
+      });
+  }, [slug]);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-slate-900 flex items-center justify-center">
+        <div className="text-gray-400">Loading…</div>
+      </div>
+    );
+  }
+
+  if (error || !doc) {
+    return (
+      <div className="min-h-screen bg-slate-900 flex items-center justify-center">
+        <div className="text-center text-gray-400">
+          <p className="text-xl mb-2">Document not found</p>
+          <p className="text-sm">This document hasn't been published yet.</p>
+        </div>
+      </div>
+    );
+  }
+
+  const formatDate = (dateStr) =>
+    dateStr
+      ? new Date(dateStr).toLocaleDateString("en-US", {
+          year: "numeric",
+          month: "long",
+          day: "numeric",
+          timeZone: "UTC",
+        })
+      : null;
+
+  return (
+    <div className="min-h-screen bg-slate-900">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+        {/* Header */}
+        <div className="mb-10">
+          <div className="flex items-center space-x-3 mb-4">
+            <FileText className="w-8 h-8 text-purple-400" />
+            <h1 className="text-4xl font-bold text-white">{doc.title}</h1>
+          </div>
+          <div className="flex flex-wrap gap-4 text-sm text-gray-400">
+            {doc.effectiveDate && (
+              <span>Effective: {formatDate(doc.effectiveDate)}</span>
+            )}
+            {doc.lastUpdated && (
+              <span>Last updated: {formatDate(doc.lastUpdated)}</span>
+            )}
+          </div>
+          {doc.intro && (
+            <p className="mt-6 text-gray-300 leading-relaxed border-l-4 border-purple-500/50 pl-4">
+              {doc.intro}
+            </p>
+          )}
+        </div>
+
+        {/* Sections */}
+        <div className="space-y-8">
+          {doc.sections?.map((section, i) => (
+            <div
+              key={i}
+              className="bg-slate-800/50 border border-purple-500/20 rounded-xl p-6"
+            >
+              <h2 className="text-xl font-bold text-purple-300 mb-4">
+                {section.heading}
+              </h2>
+              {renderBody(section.body)}
+            </div>
+          ))}
+        </div>
+
+        {/* Contact */}
+        {doc.contactEmail && (
+          <div className="mt-10 text-center text-gray-400 text-sm">
+            Questions? Contact us at{" "}
+            <a
+              href={`mailto:${doc.contactEmail}`}
+              className="text-purple-400 hover:text-purple-300"
+            >
+              {doc.contactEmail}
+            </a>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/pages/PrivacyPolicy.jsx
+++ b/src/pages/PrivacyPolicy.jsx
@@ -1,0 +1,4 @@
+import React from "react";
+import { LegalDocument } from "./LegalDocument";
+
+export const PrivacyPolicy = () => <LegalDocument slug="privacy-policy" />;

--- a/src/pages/TermsOfService.jsx
+++ b/src/pages/TermsOfService.jsx
@@ -1,0 +1,4 @@
+import React from "react";
+import { LegalDocument } from "./LegalDocument";
+
+export const TermsOfService = () => <LegalDocument slug="terms-of-service" />;

--- a/src/services/sanity.js
+++ b/src/services/sanity.js
@@ -285,6 +285,15 @@ export const queries = {
       coachName
     }
   }`),
+  getLegalDocument: (slug) =>
+    sanityClient.fetch(
+      `*[_type == "legalDocument" && slug.current == $slug][0] {
+        title, effectiveDate, lastUpdated, intro, contactEmail,
+        sections[] { heading, body }
+      }`,
+      { slug }
+    ),
+
   getNewsletterEmails: () =>
     sanityClient.fetch(`
          *[_type == "newsletterEmail" && published == true] | order(sentAt desc) {


### PR DESCRIPTION
## Summary

- Adds a `legalDocument` Sanity schema so the Privacy Policy and Terms of Service can be edited in Sanity Studio without a code deploy
- Adds `/privacy-policy` and `/terms-of-service` routes powered by a shared `LegalDocument` renderer
- Links both pages in the site footer (visible on every page)
- Updates the SMS opt-in disclosure in the newsletter signup to link to both documents
- Adds `getLegalDocument(slug)` query to the Sanity service

## Why

A2P 10DLC carrier review requires:
1. A publicly accessible Privacy Policy that includes an SMS-specific consent/opt-out section
2. A publicly accessible Terms of Service
3. Links to both documents in the SMS opt-in flow

## What reviewers should know

**The pages will show "Document not found" until content is entered in Sanity Studio.** The full draft content (section-by-section) was produced in the working session and is ready to copy-paste into Studio.

### Privacy Policy — changes from the existing policy (3/29/2024 version)

Only 4 targeted additions; everything else is word-for-word from the original:

| # | Section | Change |
|---|---|---|
| 1 | Information We Collect | Added: `Phone number (if you opt in to SMS alerts)` |
| 2 | How We Use Your Information | Added: `To send SMS text alerts for tournament updates and announcements (if you have opted in)` |
| 3 | Sharing of Information | Added MailerLite by name as the SMS/email processor |
| 4 | **New section** — SMS Communications | Entire new section: opt-in terms, STOP/HELP instructions, disclosure that consent is not a purchase condition |

The board should vote on these 4 additions before merging.

### Terms of Service

Entirely new document. Covers: website use, communications/subscriptions, intellectual property, program participation, disclaimer, limitation of liability, governing law (Idaho / Bonner County).

## Test plan

- [ ] Enter Privacy Policy content in Sanity Studio → verify `/privacy-policy` renders correctly
- [ ] Enter Terms of Service content in Sanity Studio → verify `/terms-of-service` renders correctly
- [ ] Confirm footer links appear on every page
- [ ] Confirm SMS opt-in disclosure links are correct
- [ ] Share `/privacy-policy` URL with A2P carrier for manual review