### PR TITLE
Fix WCAG 2.1 AA accessibility gaps

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,9 +28,15 @@ function App() {
     <BrowserRouter>
       <ScrollToTop />
       <div className="min-h-screen bg-slate-900 text-white flex flex-col">
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:absolute focus:z-[100] focus:top-2 focus:left-2 focus:px-4 focus:py-2 focus:bg-purple-600 focus:text-white focus:rounded-lg"
+        >
+          Skip to main content
+        </a>
         <Header />
         <AnnouncementBanner />
-        <main className="flex-grow">
+        <main id="main-content" tabIndex={-1} className="flex-grow">
           <Routes>
             <Route path="/" element={<Home />} />
             <Route path="/expecting" element={<ExpectingIndex />} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,7 @@ import { CoachHelp } from "./pages/CoachHelp";
 import { Games } from "./pages/Games";
 import { AnnouncementBanner } from "./components/common/AnnouncementBanner";
 import { ScrollToTop } from "./components/common/ScrollToTop";
+import { PageTitle } from "./components/common/PageTitle";
 import { Schedule } from "./pages/Schedule";
 import { Transparency } from "./pages/Transparency";
 import { Champions } from "./pages/Champions";
@@ -27,6 +28,7 @@ function App() {
   return (
     <BrowserRouter>
       <ScrollToTop />
+      <PageTitle />
       <div className="min-h-screen bg-slate-900 text-white flex flex-col">
         <a
           href="#main-content"

--- a/src/components/common/PageTitle.jsx
+++ b/src/components/common/PageTitle.jsx
@@ -1,0 +1,44 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+const SITE_NAME = "Idaho Esports Association";
+
+// Exact-path titles. Dynamic routes fall back to a prefix match below.
+const TITLES = {
+  "/": "Home",
+  "/expecting": "Getting Started",
+  "/about": "About",
+  "/games": "Games",
+  "/schools": "Schools",
+  "/rules": "Rules",
+  "/transparency": "Transparency",
+  "/sponsors": "Sponsors",
+  "/support": "Support Us",
+  "/schedule": "Schedule",
+  "/contact": "Contact",
+  "/coach-help": "Coach Help",
+  "/champions": "Champions",
+  "/newsletter-archive": "Newsletter Archive",
+  "/privacy-policy": "Privacy Policy",
+  "/terms-of-service": "Terms of Service",
+};
+
+// Prefix titles for dynamic routes (e.g. /expecting/:id).
+const PREFIX_TITLES = [{ prefix: "/expecting/", title: "Getting Started" }];
+
+const titleForPath = (pathname) => {
+  if (TITLES[pathname]) return TITLES[pathname];
+  const match = PREFIX_TITLES.find((p) => pathname.startsWith(p.prefix));
+  return match ? match.title : null;
+};
+
+export const PageTitle = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    const pageTitle = titleForPath(pathname);
+    document.title = pageTitle ? `${pageTitle} | ${SITE_NAME}` : SITE_NAME;
+  }, [pathname]);
+
+  return null;
+};

--- a/src/components/games/GameModal.jsx
+++ b/src/components/games/GameModal.jsx
@@ -1,7 +1,61 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { X } from "lucide-react";
 
 export const GameModal = ({ game, onClose }) => {
+  const dialogRef = useRef(null);
+  const previouslyFocused = useRef(null);
+
+  useEffect(() => {
+    if (!game) return;
+
+    // Remember what had focus so we can restore it on close.
+    previouslyFocused.current = document.activeElement;
+
+    const dialog = dialogRef.current;
+    const getFocusable = () =>
+      dialog
+        ? Array.from(
+            dialog.querySelectorAll(
+              'a[href], button:not([disabled]), input, select, textarea, [tabindex]:not([tabindex="-1"])',
+            ),
+          )
+        : [];
+
+    // Move focus into the dialog.
+    const focusable = getFocusable();
+    (focusable[0] || dialog)?.focus();
+
+    const handleKeyDown = (e) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+      if (e.key === "Tab") {
+        const items = getFocusable();
+        if (items.length === 0) return;
+        const first = items[0];
+        const last = items[items.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      // Restore focus to the trigger when the dialog unmounts.
+      if (previouslyFocused.current instanceof HTMLElement) {
+        previouslyFocused.current.focus();
+      }
+    };
+  }, [game, onClose]);
+
   if (!game) return null;
 
   const logo = game.logo || game.externalLogoUrl;
@@ -10,9 +64,17 @@ export const GameModal = ({ game, onClose }) => {
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4 overflow-y-auto">
       <div className="absolute inset-0 bg-black/60" onClick={onClose}></div>
 
-      <div className="relative w-full max-w-3xl bg-slate-900/90 border border-purple-500/30 rounded-2xl p-6 backdrop-blur-sm z-10 max-h-[90vh] overflow-y-auto">
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="game-modal-title"
+        tabIndex={-1}
+        className="relative w-full max-w-3xl bg-slate-900/90 border border-purple-500/30 rounded-2xl p-6 backdrop-blur-sm z-10 max-h-[90vh] overflow-y-auto"
+      >
         <button
           onClick={onClose}
+          aria-label="Close dialog"
           className="absolute right-4 top-4 p-2 rounded-full hover:bg-slate-800"
         >
           <X className="w-5 h-5 text-purple-300" />
@@ -32,7 +94,7 @@ export const GameModal = ({ game, onClose }) => {
           </div>
 
           <div className="flex-1">
-            <h2 className="text-2xl font-bold text-white">{game.name}</h2>
+            <h2 id="game-modal-title" className="text-2xl font-bold text-white">{game.name}</h2>
             <p className="text-gray-400 mt-1">
               {game.genre} • {game.esrb}
             </p>

--- a/src/components/layout/Footer.jsx
+++ b/src/components/layout/Footer.jsx
@@ -141,7 +141,7 @@ export const Footer = () => {
                 href="https://app.candid.org/profile/15079270/idaho-esports-association-93-2128403/?pkId=dbdcfbf4-f040-410f-814a-f3ec72eaa509"
                 target="_blank"
               >
-                <img src="https://widgets.guidestar.org/prod/v1/pdp/transparency-seal/15079270/svg" />{" "}
+                <img src="https://widgets.guidestar.org/prod/v1/pdp/transparency-seal/15079270/svg" alt="Candid (GuideStar) Transparency Seal" />{" "}
               </a>
               <div className="text-left">
                 <p className="text-sm text-gray-400">Verified Non-Profit</p>

--- a/src/components/layout/Footer.jsx
+++ b/src/components/layout/Footer.jsx
@@ -145,7 +145,7 @@ export const Footer = () => {
               </a>
               <div className="text-left">
                 <p className="text-sm text-gray-400">Verified Non-Profit</p>
-                <p className="text-xs text-gray-500">
+                <p className="text-xs text-gray-400">
                   GuideStar/Candid Certified
                 </p>
               </div>
@@ -154,7 +154,7 @@ export const Footer = () => {
             {/* Right side - 501(c)(3) info */}
             <div className="text-center md:text-right text-gray-400 text-sm">
               <p className="font-semibold">501(c)(3) Non-Profit Organization</p>
-              <p className="text-xs text-gray-500 mt-1">
+              <p className="text-xs text-gray-400 mt-1">
                 Tax ID: 93-2128403 • Donations are tax-deductible
               </p>
             </div>
@@ -169,7 +169,7 @@ export const Footer = () => {
           <p className="mt-2 text-sm">
             Committed to transparency and fair play in Idaho gaming.
           </p>
-          <div className="mt-3 flex justify-center gap-4 text-xs text-gray-500">
+          <div className="mt-3 flex justify-center gap-4 text-xs text-gray-400">
             <a href="/privacy-policy" className="hover:text-purple-400 transition-colors">
               Privacy Policy
             </a>

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -45,6 +45,21 @@ export const Header = () => {
 
   const isActive = (path) => location.pathname === path;
 
+  // Close the open dropdown when focus leaves the group entirely.
+  const handleGroupBlur = (e, title) => {
+    if (!e.currentTarget.contains(e.relatedTarget) && openDropdown === title) {
+      setOpenDropdown(null);
+    }
+  };
+
+  // Escape closes the dropdown and returns focus to its trigger button.
+  const handleGroupKeyDown = (e, title) => {
+    if (e.key === "Escape" && openDropdown === title) {
+      setOpenDropdown(null);
+      e.currentTarget.querySelector("button")?.focus();
+    }
+  };
+
   return (
     <nav className="sticky top-0 z-50 bg-slate-900/95 backdrop-blur-md border-b border-purple-500/30">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -75,6 +90,8 @@ export const Header = () => {
                 className="relative group"
                 onMouseEnter={() => setOpenDropdown(group.title)}
                 onMouseLeave={() => setOpenDropdown(null)}
+                onBlur={(e) => handleGroupBlur(e, group.title)}
+                onKeyDown={(e) => handleGroupKeyDown(e, group.title)}
               >
                 <button
                   onClick={() =>
@@ -89,17 +106,22 @@ export const Header = () => {
                   }`}
                   aria-haspopup="true"
                   aria-expanded={openDropdown === group.title}
+                  aria-controls={`dropdown-${group.title}`}
                 >
                   {group.title}
                 </button>
 
                 {openDropdown === group.title && (
-                  <div className="absolute left-0 mt-0 w-48 bg-slate-900 border border-purple-500/30 rounded-md shadow-lg z-50 pt-2">
+                  <div
+                    id={`dropdown-${group.title}`}
+                    className="absolute left-0 mt-0 w-48 bg-slate-900 border border-purple-500/30 rounded-md shadow-lg z-50 pt-2"
+                  >
                     <div className="py-2">
                       {group.items.map((item) => (
                         <Link
                           key={item.path}
                           to={item.path}
+                          onClick={() => setOpenDropdown(null)}
                           className={`block px-4 py-2 text-sm ${isActive(item.path) ? "bg-purple-600 text-white" : "text-gray-200 hover:bg-slate-800"}`}
                         >
                           {item.name}
@@ -117,6 +139,8 @@ export const Header = () => {
             onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
             className="lg:hidden text-white p-2"
             aria-label="Toggle menu"
+            aria-expanded={mobileMenuOpen}
+            aria-controls="mobile-menu"
           >
             {mobileMenuOpen ? (
               <X className="w-6 h-6" />
@@ -129,7 +153,7 @@ export const Header = () => {
 
       {/* Mobile Navigation */}
       {mobileMenuOpen && (
-        <div className="lg:hidden bg-slate-800 border-t border-purple-500/30">
+        <div id="mobile-menu" className="lg:hidden bg-slate-800 border-t border-purple-500/30">
           <div className="px-4 py-4 space-y-4">
             <Link
               to="/"

--- a/src/components/newsletter/NewsletterSignup.jsx
+++ b/src/components/newsletter/NewsletterSignup.jsx
@@ -158,7 +158,7 @@ export const NewsletterSignup = ({ inline = false }) => {
                 onChange={(e) => setPhone(e.target.value)}
                 className="w-full px-4 py-2 bg-slate-900 border border-purple-500/30 rounded-lg text-white focus:outline-none focus:border-purple-500"
               />
-              <p className="text-xs text-gray-500 leading-relaxed">
+              <p className="text-xs text-gray-400 leading-relaxed">
                 By checking this box and providing your phone number, you
                 consent to receive recurring automated text messages from Idaho
                 Esports Association. Message frequency varies. Msg &amp; data

--- a/src/components/newsletter/NewsletterSignup.jsx
+++ b/src/components/newsletter/NewsletterSignup.jsx
@@ -64,9 +64,13 @@ export const NewsletterSignup = ({ inline = false }) => {
 
   if (inline) {
     return (
-      <div className="space-y-2">
+      <form onSubmit={handleSubmit} className="space-y-2">
         <div className="flex flex-col sm:flex-row gap-2">
+          <label htmlFor="newsletter-email-inline" className="sr-only">
+            Your email
+          </label>
           <input
+            id="newsletter-email-inline"
             type="email"
             placeholder="Your email"
             value={email}
@@ -75,7 +79,7 @@ export const NewsletterSignup = ({ inline = false }) => {
             required
           />
           <button
-            onClick={handleSubmit}
+            type="submit"
             disabled={status === "loading"}
             className="px-6 py-2 bg-gradient-to-r from-purple-600 to-pink-600 rounded-lg text-white font-semibold hover:from-purple-700 hover:to-pink-700 transition-all disabled:opacity-50 whitespace-nowrap"
           >
@@ -83,12 +87,12 @@ export const NewsletterSignup = ({ inline = false }) => {
           </button>
         </div>
         {status === "success" && (
-          <p className="text-green-400 text-sm">✓ Successfully subscribed!</p>
+          <p role="status" className="text-green-400 text-sm">✓ Successfully subscribed!</p>
         )}
         {status === "error" && (
-          <p className="text-red-400 text-sm">✗ {errorMessage}</p>
+          <p role="alert" className="text-red-400 text-sm">✗ {errorMessage}</p>
         )}
-      </div>
+      </form>
     );
   }
 
@@ -103,15 +107,23 @@ export const NewsletterSignup = ({ inline = false }) => {
         updates.
       </p>
 
-      <div className="space-y-3">
+      <form onSubmit={handleSubmit} className="space-y-3">
+        <label htmlFor="newsletter-name" className="sr-only">
+          Your name (optional)
+        </label>
         <input
+          id="newsletter-name"
           type="text"
           placeholder="Your name (optional)"
           value={name}
           onChange={(e) => setName(e.target.value)}
           className="w-full px-4 py-2 bg-slate-900 border border-purple-500/30 rounded-lg text-white focus:outline-none focus:border-purple-500"
         />
+        <label htmlFor="newsletter-email" className="sr-only">
+          Your email
+        </label>
         <input
+          id="newsletter-email"
           type="email"
           placeholder="Your email"
           value={email}
@@ -135,7 +147,11 @@ export const NewsletterSignup = ({ inline = false }) => {
 
           {smsOptIn && (
             <div className="space-y-2 pl-7">
+              <label htmlFor="newsletter-phone" className="sr-only">
+                Phone number
+              </label>
               <input
+                id="newsletter-phone"
                 type="tel"
                 placeholder="Phone number (e.g. 208-555-0100)"
                 value={phone}
@@ -164,7 +180,7 @@ export const NewsletterSignup = ({ inline = false }) => {
           )}
         </div>
         <button
-          onClick={handleSubmit}
+          type="submit"
           disabled={status === "loading"}
           className="w-full px-6 py-3 bg-gradient-to-r from-purple-600 to-pink-600 rounded-lg text-white font-semibold hover:from-purple-700 hover:to-pink-700 transition-all disabled:opacity-50"
         >
@@ -172,16 +188,16 @@ export const NewsletterSignup = ({ inline = false }) => {
         </button>
 
         {status === "success" && (
-          <div className="bg-green-900/30 border border-green-500/50 rounded-lg p-3 text-green-300 text-sm">
+          <div role="status" className="bg-green-900/30 border border-green-500/50 rounded-lg p-3 text-green-300 text-sm">
             ✓ Successfully subscribed! Check your email to confirm.
           </div>
         )}
         {status === "error" && (
-          <div className="bg-red-900/30 border border-red-500/50 rounded-lg p-3 text-red-300 text-sm">
+          <div role="alert" className="bg-red-900/30 border border-red-500/50 rounded-lg p-3 text-red-300 text-sm">
             ✗ {errorMessage || "Something went wrong. Please try again."}
           </div>
         )}
-      </div>
+      </form>
     </div>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -1,1 +1,21 @@
 @import "tailwindcss";
+
+/* Always show a visible focus ring for keyboard users (WCAG 2.4.7).
+   Uses !important to override per-element `focus:outline-none` utilities. */
+*:focus-visible {
+  outline: 2px solid #d8b4fe !important; /* purple-300 */
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+/* Respect users who ask for reduced motion (WCAG 2.3.3). */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -253,7 +253,7 @@ export const About = () => {
               href="https://app.candid.org/profile/15079270/idaho-esports-association-93-2128403/?pkId=dbdcfbf4-f040-410f-814a-f3ec72eaa509"
               target="_blank"
             >
-              <img src="https://widgets.guidestar.org/prod/v1/pdp/transparency-seal/15079270/svg" />{" "}
+              <img src="https://widgets.guidestar.org/prod/v1/pdp/transparency-seal/15079270/svg" alt="Candid (GuideStar) Transparency Seal" />{" "}
             </a>
             <p className="text-center text-sm text-gray-400 mt-3">
               Verified by

--- a/src/pages/Champions.jsx
+++ b/src/pages/Champions.jsx
@@ -53,7 +53,7 @@ const ChampionshipCard = ({ result, isExpanded, onToggle }) => {
             {/* Roster - Only show when expanded */}
             {isExpanded && data.roster && data.roster.length > 0 && (
               <div className="mt-3 pt-3 border-t border-slate-700">
-                <p className="text-xs text-gray-500 mb-1">Roster:</p>
+                <p className="text-xs text-gray-400 mb-1">Roster:</p>
                 <div className="flex flex-wrap gap-1">
                   {data.roster.map((player, idx) => (
                     <span key={idx} className="text-xs bg-slate-800 text-gray-300 px-2 py-1 rounded">
@@ -95,7 +95,7 @@ const ChampionshipCard = ({ result, isExpanded, onToggle }) => {
                 {result.division && ` • ${result.division}`}
               </p>
               
-              <div className="flex flex-wrap gap-3 mt-2 text-sm text-gray-500">
+              <div className="flex flex-wrap gap-3 mt-2 text-sm text-gray-400">
                 <span className="flex items-center gap-1">
                   <Calendar className="w-4 h-4" />
                   {new Date(result.eventDate).toLocaleDateString('en-US', { 
@@ -288,7 +288,7 @@ export const Champions = () => {
         </div>
       ) : championships.length === 0 ? (
         <div className="bg-slate-800/50 backdrop-blur-sm border border-purple-500/30 rounded-xl p-12 text-center">
-          <Trophy className="w-16 h-16 text-gray-500 mx-auto mb-4" />
+          <Trophy className="w-16 h-16 text-gray-400 mx-auto mb-4" />
           <p className="text-gray-400 text-lg">
             Championship results will be posted here after each tournament season.
           </p>
@@ -306,7 +306,7 @@ export const Champions = () => {
                   placeholder="Search by game, school, or team..."
                   value={searchTerm}
                   onChange={(e) => setSearchTerm(e.target.value)}
-                  className="w-full pl-10 pr-4 py-3 bg-slate-900 border border-purple-500/30 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-purple-500 transition-colors"
+                  className="w-full pl-10 pr-4 py-3 bg-slate-900 border border-purple-500/30 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:border-purple-500 transition-colors"
                 />
               </div>
 

--- a/src/pages/CoachHelp.jsx
+++ b/src/pages/CoachHelp.jsx
@@ -292,7 +292,7 @@ export const CoachHelp = () => {
             </button>
 
             {status === "success" && (
-              <div className="bg-green-900/30 border border-green-500/50 rounded-lg p-4 flex items-start space-x-3">
+              <div role="status" className="bg-green-900/30 border border-green-500/50 rounded-lg p-4 flex items-start space-x-3">
                 <CheckCircle className="w-5 h-5 text-green-400 flex-shrink-0 mt-0.5" />
                 <div>
                   <p className="text-green-300 font-semibold">
@@ -307,7 +307,7 @@ export const CoachHelp = () => {
             )}
 
             {status === "error" && (
-              <div className="bg-red-900/30 border border-red-500/50 rounded-lg p-4 flex items-start space-x-3">
+              <div role="alert" className="bg-red-900/30 border border-red-500/50 rounded-lg p-4 flex items-start space-x-3">
                 <AlertCircle className="w-5 h-5 text-red-400 flex-shrink-0 mt-0.5" />
                 <div>
                   <p className="text-red-300 font-semibold">

--- a/src/pages/CoachHelp.jsx
+++ b/src/pages/CoachHelp.jsx
@@ -113,7 +113,7 @@ export const CoachHelp = () => {
                   required
                   value={formData.coachName}
                   onChange={handleChange}
-                  className="w-full px-4 py-3 bg-slate-900 border border-cyan-500/30 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-cyan-500 transition-colors"
+                  className="w-full px-4 py-3 bg-slate-900 border border-cyan-500/30 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:border-cyan-500 transition-colors"
                   placeholder="Your name"
                 />
               </div>
@@ -132,7 +132,7 @@ export const CoachHelp = () => {
                   required
                   value={formData.email}
                   onChange={handleChange}
-                  className="w-full px-4 py-3 bg-slate-900 border border-cyan-500/30 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-cyan-500 transition-colors"
+                  className="w-full px-4 py-3 bg-slate-900 border border-cyan-500/30 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:border-cyan-500 transition-colors"
                   placeholder="your.email@example.com"
                 />
               </div>
@@ -151,7 +151,7 @@ export const CoachHelp = () => {
                   required
                   value={formData.schoolName}
                   onChange={handleChange}
-                  className="w-full px-4 py-3 bg-slate-900 border border-cyan-500/30 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-cyan-500 transition-colors"
+                  className="w-full px-4 py-3 bg-slate-900 border border-cyan-500/30 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:border-cyan-500 transition-colors"
                   placeholder="Your school name"
                 />
               </div>
@@ -169,7 +169,7 @@ export const CoachHelp = () => {
                   name="phone"
                   value={formData.phone}
                   onChange={handleChange}
-                  className="w-full px-4 py-3 bg-slate-900 border border-cyan-500/30 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-cyan-500 transition-colors"
+                  className="w-full px-4 py-3 bg-slate-900 border border-cyan-500/30 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:border-cyan-500 transition-colors"
                   placeholder="(208) 555-0000"
                 />
               </div>
@@ -245,7 +245,7 @@ export const CoachHelp = () => {
                   required
                   value={formData.subject}
                   onChange={handleChange}
-                  className="w-full px-4 py-3 bg-slate-900 border border-cyan-500/30 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-cyan-500 transition-colors"
+                  className="w-full px-4 py-3 bg-slate-900 border border-cyan-500/30 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:border-cyan-500 transition-colors"
                   placeholder="Brief summary of your request"
                 />
               </div>
@@ -264,7 +264,7 @@ export const CoachHelp = () => {
                   rows="8"
                   value={formData.description}
                   onChange={handleChange}
-                  className="w-full px-4 py-3 bg-slate-900 border border-cyan-500/30 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-cyan-500 transition-colors resize-none"
+                  className="w-full px-4 py-3 bg-slate-900 border border-cyan-500/30 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:border-cyan-500 transition-colors resize-none"
                   placeholder="Please provide detailed information about your request, including any relevant dates, tournaments, or player names..."
                 />
               </div>

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -59,8 +59,8 @@ export const Contact = () => {
         {/* Contact Form */}
         <div className="bg-slate-800/50 backdrop-blur-sm border border-purple-500/30 rounded-xl p-8">
           <h2 className="text-2xl font-bold text-white mb-6">Send us a Message</h2>
-          
-          <div className="space-y-4">
+
+          <form onSubmit={handleSubmit} className="space-y-4">
             <div>
               <label htmlFor="name" className="block text-sm font-medium text-gray-300 mb-2">
                 Name *
@@ -126,7 +126,7 @@ export const Contact = () => {
             </div>
 
             <button
-              onClick={handleSubmit}
+              type="submit"
               disabled={status === 'sending'}
               className="w-full px-6 py-4 bg-gradient-to-r from-purple-600 to-pink-600 rounded-lg text-white font-semibold hover:from-purple-700 hover:to-pink-700 transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center space-x-2"
             >
@@ -144,7 +144,7 @@ export const Contact = () => {
             </button>
 
             {status === 'success' && (
-              <div className="bg-green-900/30 border border-green-500/50 rounded-lg p-4 flex items-start space-x-3">
+              <div role="status" className="bg-green-900/30 border border-green-500/50 rounded-lg p-4 flex items-start space-x-3">
                 <CheckCircle className="w-5 h-5 text-green-400 flex-shrink-0 mt-0.5" />
                 <div>
                   <p className="text-green-300 font-semibold">Message sent successfully!</p>
@@ -156,7 +156,7 @@ export const Contact = () => {
             )}
 
             {status === 'error' && (
-              <div className="bg-red-900/30 border border-red-500/50 rounded-lg p-4 flex items-start space-x-3">
+              <div role="alert" className="bg-red-900/30 border border-red-500/50 rounded-lg p-4 flex items-start space-x-3">
                 <AlertCircle className="w-5 h-5 text-red-400 flex-shrink-0 mt-0.5" />
                 <div>
                   <p className="text-red-300 font-semibold">Failed to send message</p>
@@ -166,7 +166,7 @@ export const Contact = () => {
                 </div>
               </div>
             )}
-          </div>
+          </form>
         </div>
 
         {/* Contact Info & Alternative Methods */}

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -72,7 +72,7 @@ export const Contact = () => {
                 required
                 value={formData.name}
                 onChange={handleChange}
-                className="w-full px-4 py-3 bg-slate-900 border border-purple-500/30 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-purple-500 transition-colors"
+                className="w-full px-4 py-3 bg-slate-900 border border-purple-500/30 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:border-purple-500 transition-colors"
                 placeholder="Your name"
               />
             </div>
@@ -88,7 +88,7 @@ export const Contact = () => {
                 required
                 value={formData.email}
                 onChange={handleChange}
-                className="w-full px-4 py-3 bg-slate-900 border border-purple-500/30 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-purple-500 transition-colors"
+                className="w-full px-4 py-3 bg-slate-900 border border-purple-500/30 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:border-purple-500 transition-colors"
                 placeholder="your.email@example.com"
               />
             </div>
@@ -104,7 +104,7 @@ export const Contact = () => {
                 required
                 value={formData.subject}
                 onChange={handleChange}
-                className="w-full px-4 py-3 bg-slate-900 border border-purple-500/30 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-purple-500 transition-colors"
+                className="w-full px-4 py-3 bg-slate-900 border border-purple-500/30 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:border-purple-500 transition-colors"
                 placeholder="What's this about?"
               />
             </div>
@@ -120,7 +120,7 @@ export const Contact = () => {
                 rows="6"
                 value={formData.message}
                 onChange={handleChange}
-                className="w-full px-4 py-3 bg-slate-900 border border-purple-500/30 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-purple-500 transition-colors resize-none"
+                className="w-full px-4 py-3 bg-slate-900 border border-purple-500/30 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:border-purple-500 transition-colors resize-none"
                 placeholder="Tell us more..."
               />
             </div>

--- a/src/pages/ExpectingSeries/Article.jsx
+++ b/src/pages/ExpectingSeries/Article.jsx
@@ -112,7 +112,7 @@ const PortableTextRenderer = ({ content }) => {
             className="rounded-lg w-full"
           />
           {block.alt && (
-            <p className="text-sm text-gray-500 mt-2 text-center italic">
+            <p className="text-sm text-gray-400 mt-2 text-center italic">
               {block.alt}
             </p>
           )}

--- a/src/pages/ExpectingSeries/Index.jsx
+++ b/src/pages/ExpectingSeries/Index.jsx
@@ -180,7 +180,7 @@ export const ExpectingIndex = () => {
                       )}
 
                       {article.publishedAt && (
-                        <div className="flex items-center space-x-2 text-sm text-gray-500">
+                        <div className="flex items-center space-x-2 text-sm text-gray-400">
                           <Calendar className="w-4 h-4" />
                           <span>
                             {new Date(article.publishedAt).toLocaleDateString(

--- a/src/pages/Games.jsx
+++ b/src/pages/Games.jsx
@@ -46,7 +46,7 @@ export const Games = () => {
           <div className="relative">
             <input
               type="text"
-              className="w-full pl-4 pr-4 py-3 bg-slate-900 border border-purple-500/30 rounded-lg text-white placeholder-gray-500"
+              className="w-full pl-4 pr-4 py-3 bg-slate-900 border border-purple-500/30 rounded-lg text-white placeholder-gray-400"
               placeholder="Search games..."
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}

--- a/src/pages/NewsletterArchive.jsx
+++ b/src/pages/NewsletterArchive.jsx
@@ -88,7 +88,7 @@ const EmailCard = ({ email }) => {
             <h3 className="text-lg font-bold text-white leading-snug group-hover:text-purple-200 transition-colors">
               {email.subject}
             </h3>
-            <div className="flex items-center gap-2 mt-1.5 text-sm text-gray-500">
+            <div className="flex items-center gap-2 mt-1.5 text-sm text-gray-400">
               <Calendar className="w-3.5 h-3.5 flex-shrink-0" />
               <time dateTime={email.sentAt}>
                 {new Date(email.sentAt).toLocaleDateString('en-US', {
@@ -138,7 +138,7 @@ const EmailCard = ({ email }) => {
         {/* Highlighted links */}
         {email.highlightedLinks && email.highlightedLinks.length > 0 && (
           <div className="border-t border-slate-700/50 pt-4 mt-2">
-            <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+            <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">
               Key Links from this Email
             </p>
             <ul className="space-y-1.5">
@@ -296,7 +296,7 @@ export const NewsletterArchive = () => {
                 onChange={e => setSearchTerm(e.target.value)}
                 className="
                   w-full pl-12 pr-4 py-3 bg-slate-900 border border-purple-500/30 rounded-lg
-                  text-white placeholder-gray-500
+                  text-white placeholder-gray-400
                   focus:outline-none focus:border-purple-500
                   transition-colors
                 "
@@ -307,7 +307,7 @@ export const NewsletterArchive = () => {
             {allTags.length > 0 && (
               <div>
                 <div className="flex items-center gap-2 mb-3">
-                  <Tag className="w-4 h-4 text-gray-500" />
+                  <Tag className="w-4 h-4 text-gray-400" />
                   <span className="text-sm font-semibold text-gray-400 uppercase tracking-wider">
                     Filter by Topic
                   </span>

--- a/src/pages/Rules.jsx
+++ b/src/pages/Rules.jsx
@@ -81,7 +81,7 @@ const RuleCard = ({ rule, isOpen, onToggle }) => {
         </div>
         <div className="flex items-center space-x-4">
           {rule.lastUpdated && (
-            <span className="text-sm text-gray-500 hidden sm:block">
+            <span className="text-sm text-gray-400 hidden sm:block">
               Updated{" "}
               {new Date(rule.lastUpdated).toLocaleDateString("en-US", {
                 month: "short",
@@ -255,7 +255,7 @@ export const Rules = () => {
                   placeholder="Search rules..."
                   value={searchTerm}
                   onChange={(e) => setSearchTerm(e.target.value)}
-                  className="w-full pl-10 pr-4 py-3 bg-slate-900 border border-purple-500/30 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-purple-500 transition-colors"
+                  className="w-full pl-10 pr-4 py-3 bg-slate-900 border border-purple-500/30 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:border-purple-500 transition-colors"
                 />
               </div>
 

--- a/src/pages/Schedule.jsx
+++ b/src/pages/Schedule.jsx
@@ -110,7 +110,7 @@ const DayColumn = ({ day, scheduleItems }) => {
       {/* Games List */}
       <div className="p-4 space-y-3">
         {scheduleItems.length === 0 ? (
-          <div className="text-center py-8 text-gray-500">
+          <div className="text-center py-8 text-gray-400">
             No games scheduled
           </div>
         ) : (
@@ -255,11 +255,11 @@ export const Schedule = () => {
         </div>
       ) : scheduleItems.length === 0 && selectedDivision === 'all' ? (
         <div className="bg-slate-800/50 backdrop-blur-sm border border-purple-500/30 rounded-xl p-12 text-center">
-          <Calendar className="w-16 h-16 text-gray-500 mx-auto mb-4" />
+          <Calendar className="w-16 h-16 text-gray-400 mx-auto mb-4" />
           <p className="text-gray-400 text-lg mb-2">
             No games currently scheduled
           </p>
-          <p className="text-gray-500 text-sm">
+          <p className="text-gray-400 text-sm">
             Check back soon for the latest schedule, or contact us for more information.
           </p>
         </div>

--- a/src/pages/Transparency.jsx
+++ b/src/pages/Transparency.jsx
@@ -150,7 +150,7 @@ export const Transparency = () => {
                   href="https://app.candid.org/profile/15079270/idaho-esports-association-93-2128403/?pkId=dbdcfbf4-f040-410f-814a-f3ec72eaa509"
                   target="_blank"
                 >
-                  <img src="https://widgets.guidestar.org/prod/v1/pdp/transparency-seal/15079270/svg" />{" "}
+                  <img src="https://widgets.guidestar.org/prod/v1/pdp/transparency-seal/15079270/svg" alt="Candid (GuideStar) Transparency Seal" />{" "}
                 </a>
                 <p className="text-sm text-gray-400 mt-3">
                   GuideStar/Candid

--- a/src/pages/Transparency.jsx
+++ b/src/pages/Transparency.jsx
@@ -283,7 +283,7 @@ export const Transparency = () => {
                               {member.position}
                             </p>
                             {member.termStart && (
-                              <p className="text-sm text-gray-500 mt-1">
+                              <p className="text-sm text-gray-400 mt-1">
                                 Term: {new Date(member.termStart).getFullYear()}{" "}
                                 -{" "}
                                 {member.termEnd
@@ -455,7 +455,7 @@ export const Transparency = () => {
                               {report.fiscalPeriod || ""}
                             </p>
                           </div>
-                          <span className="text-sm text-gray-500">
+                          <span className="text-sm text-gray-400">
                             {new Date(report.reportDate).toLocaleDateString(
                               "en-US",
                               {


### PR DESCRIPTION
## Why

Brings the site to **WCAG 2.1 Level AA** — the standard now being enforced by **ADA Title II** (DOJ 2024 rule, deadlines April 2026/2027), the **EU Accessibility Act** (in force since June 2025), and several state laws (Colorado, California, etc.). These are also the issues most commonly cited in ADA web demand letters.

This PR addresses the full set of findings from an accessibility audit of the site.

## What changed

### Forms & interactive
| Area | Fix | WCAG |
|---|---|---|
| **Contact form** (`Contact.jsx`) | Converted to a real `<form>` with `type="submit"` button — restores Enter-to-submit and native `required` validation; status messages get live regions | 2.1.1, 3.3.1, 4.1.3 |
| **Newsletter** (`NewsletterSignup.jsx`) | Both inline & full variants are real `<form>`s now; added `sr-only` `<label>`s to the previously placeholder-only name/email/phone inputs; live-region status | 2.1.1, 1.3.1, 4.1.3 |
| **Game modal** (`GameModal.jsx`) | Now a proper dialog: `role="dialog"`, `aria-modal`, `aria-labelledby`, **Escape to close, focus trap, focus return** to trigger, and `aria-label` on the icon-only close button | 2.4.3, 4.1.2 |
| **Coach Help** (`CoachHelp.jsx`) | Submit success/error messages use `role="status"`/`role="alert"` | 4.1.3 |
| **Dropdown nav** (`Header.jsx`) | Escape closes & returns focus to trigger; focus-out closes the menu; clicking an item closes it; `aria-controls` added; mobile button gains `aria-expanded`/`aria-controls` | 2.1.1, 4.1.2 |

### Structure & global
| Area | Fix | WCAG |
|---|---|---|
| **App shell** (`App.jsx`) | Skip-to-content link + `<main id="main-content">` landmark | 2.4.1 |
| **Page titles** (`PageTitle.jsx`) | Per-route `document.title` instead of one static title for the whole SPA | 2.4.2 |
| **Reduced motion** (`index.css`) | Global `prefers-reduced-motion` query neutralizes animations/transitions/scroll | 2.3.3 |
| **Focus indicators** (`index.css`) | Global `:focus-visible` outline so keyboard focus is always visible (overrides per-element `focus:outline-none`) | 2.4.7 |
| **Color contrast** (12 files) | Promoted muted `gray-500` body text & `placeholder-gray-500` (~3.4–3.7:1 on the dark theme) to `gray-400` (~6.4–7.0:1), clearing the 4.5:1 minimum | 1.4.3 |
| **Seals** (`Footer.jsx`, `About.jsx`, `Transparency.jsx`) | Added `alt` text to GuideStar transparency seal images | 1.1.1 |

## Reviewer notes

- `npm run build` passes. ESLint is clean on all changed files. (There is one **pre-existing** lint error in `Champions.jsx` — a component defined during render — that is unrelated to this PR and present on `main`.)
- The skip link and `sr-only` labels use Tailwind's `sr-only` / `focus:not-sr-only`, so they're only visible on keyboard focus.
- The dropdown nav keeps the link-disclosure pattern (no `role="menu"`), appropriate since it doesn't implement full arrow-key menu navigation.
- Contrast: the site is dark-themed throughout with no light surfaces, so lightening the muted grays only improves contrast everywhere. The two remaining `gray-600` uses are large decorative empty-state icons (exempt from 1.4.11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)