### PR TITLE
fix: state concrete SMS message frequency for A2P 10DLC compliance

### DIFF
--- a/src/components/newsletter/NewsletterSignup.jsx
+++ b/src/components/newsletter/NewsletterSignup.jsx
@@ -161,8 +161,8 @@ export const NewsletterSignup = ({ inline = false }) => {
               <p className="text-xs text-gray-400 leading-relaxed">
                 By checking this box and providing your phone number, you
                 consent to receive recurring automated text messages from Idaho
-                Esports Association. Message frequency varies. Msg &amp; data
-                rates may apply. Reply{" "}
+                Esports Association. Message frequency: up to 4 msgs/month.
+                Msg &amp; data rates may apply. Reply{" "}
                 <strong className="text-gray-400">STOP</strong> to cancel,{" "}
                 <strong className="text-gray-400">HELP</strong> for help.
                 Consent is not a condition of purchase or participation.


### PR DESCRIPTION
## Summary
- Carrier review of our A2P 10DLC application flagged the SMS opt-in disclosure's "Message frequency varies" as too vague.
- Replaces it with a concrete frequency: "up to 4 msgs/month."

## Test plan
- [x] Reviewed remaining CTA elements (unchecked checkbox by default, non-mandatory phone field, org identity, opt-out/HELP instructions, Privacy Policy/Terms links, "not a condition of purchase") against A2P 10DLC requirements — already compliant
- [ ] Visually confirm the updated SMS consent copy renders correctly on the newsletter signup form

🤖 Generated with [Claude Code](https://claude.com/claude-code)